### PR TITLE
keyboard short cut to move states

### DIFF
--- a/public/js/map.js
+++ b/public/js/map.js
@@ -104,13 +104,13 @@ var stateTotals = {}
 var us = null;
 
 
-var switchModeButton = d3.select('#switchModeButton').html('Move');
+var switchModeButton = d3.select('#switchModeButton').html('<u>M</u>ove');
 var switchModeFunction = function() {
   if (currentMode === 'pickup') {
-    switchModeButton.html('Cancel move').classed('btn-danger', false).classed('btn-warning', true);
+    switchModeButton.html('Cancel <u>m</u>ove').classed('btn-danger', false).classed('btn-warning', true);
     currentMode = 'dropoff';
   } else {
-    switchModeButton.html('Move').classed('btn-danger', true).classed('btn-warning', false);
+    switchModeButton.html('<u>M</u>ove').classed('btn-danger', true).classed('btn-warning', false);
     currentMode = 'pickup';
   }
 }

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -115,6 +115,12 @@ var switchModeFunction = function() {
   }
 }
 switchModeButton.on('click', switchModeFunction);
+// keyboard shortcut to activate moving counties
+d3.select("body").on("keydown", function(ev) {
+  if (d3.event.keyCode==77) {
+    switchModeFunction()
+  };
+});
 
 var countyModeButton = d3.select("#countyModeButton").html("Hide Counties");
 var countyModeFunction = function () {

--- a/public/map.html
+++ b/public/map.html
@@ -51,7 +51,7 @@
       </div>
       <div class="row">
         <div class="col-sm-12">
-          <button type="button" class="btn btn-danger btn-md btn-block btn-space" id="switchModeButton">Move</button>
+          <button type="button" class="btn btn-danger btn-md btn-block btn-space" id="switchModeButton"><u>M</u>ove</button>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
Hey Kevin,

I've added a small feature to allow pressing 'm' to activate the 'Move' button.

![keyboardshortcut](https://cloud.githubusercontent.com/assets/934880/21583148/3df61738-d028-11e6-92a9-9dfce8c39878.gif)

The first commit (5bf9265) adds the functionality, and the second(fe4169c
) underlines the m in Move on the button.

Looking though the forks, @herbiemarkwort has some great stuff coming up, and my second commit might interfere with his work, so feel free to merge only the first commit. 

-Evan